### PR TITLE
Add xsbt and xsbti on same import group as sbt

### DIFF
--- a/src/main/resources/default.scalafix.conf
+++ b/src/main/resources/default.scalafix.conf
@@ -7,7 +7,7 @@ SortImports.blocks = [
   "scala.",
   "io.gatling.",
   "*",
-  "sbt."
+  "re:x?sbti?\\."
 ]
 
 SortImports.asciiSort = false


### PR DESCRIPTION
Motivation:
gatling uses classes in xsbt and xsbti packages.

Modifications:
Change last import group rule to include additional xsbt and xsbti packages

Result:
gatling will be able to use xsbt and xsbti shadowing

Possible impact:
This sort a hypothetical sbti package altogether with the wanted ones.