### PR TITLE
Add default sonatype profile name

### DIFF
--- a/src/main/scala/io/gatling/build/GatlingOssPlugin.scala
+++ b/src/main/scala/io/gatling/build/GatlingOssPlugin.scala
@@ -64,6 +64,7 @@ object GatlingOssPlugin extends AutoPlugin {
   override def projectSettings: Seq[Def.Setting[_]] = Seq(
     licenses := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")),
     headerLicense := ApacheV2License,
+    sonatypeProfileName := "io.gatling",
     publishTo := {
       if (gatlingPublishToSonatype.value) {
         sonatypePublishTo.value


### PR DESCRIPTION
Motivation:
Avoid to configure the same thing everywhere

Modifications:
Default value "io.gatling" for sonatypeProfileName settings

Result:
No nee to override sonatypeProfileName when groupId is somehting else than "io.gatling"