### PR TITLE
Deactivate scalafix and scalafmt on compile on CI, closes OPS-74

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,8 @@ lazy val root = (project in file("."))
 addCommandAlias(
   "ci-checks",
   List(
-    "all clean scalafmtSbtCheck scalafmtCheckAll",
+    "all clean",
+    "all scalafmtSbtCheck scalafmtCheckAll",
     "all gatlingScalafixCheck",
     "test",
     "scripted"

--- a/src/main/scala/io/gatling/build/automated/GatlingAutomatedScalafmtPlugin.scala
+++ b/src/main/scala/io/gatling/build/automated/GatlingAutomatedScalafmtPlugin.scala
@@ -27,10 +27,6 @@ object GatlingAutomatedScalafmtPlugin extends AutoPlugin {
 
   override def requires: Plugins = ScalafmtPlugin && GatlingBuildConfigPlugin
 
-  override def globalSettings: Seq[Def.Setting[_]] = Seq(
-    scalafmtOnCompile := true
-  )
-
   import GatlingBuildConfigPlugin.GatlingBuildConfigKeys._
 
   private lazy val scalafmtConfigFileSetting = Def.setting { gatlingBuildConfigDirectory.value / ".scalafmt.conf" }
@@ -40,6 +36,7 @@ object GatlingAutomatedScalafmtPlugin extends AutoPlugin {
   )
 
   override def projectSettings: Seq[Def.Setting[_]] = Seq(
+    scalafmtOnCompile := !sys.env.getOrElse("CI", "false").toBoolean,
     scalafmtConfig := scalafmtWriteConfigFile.value
   )
 }

--- a/src/sbt-test/gatling-build-plugin/loadPlugin/project/build.properties
+++ b/src/sbt-test/gatling-build-plugin/loadPlugin/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.4.9

--- a/src/sbt-test/gatling-build-plugin/scalaVersion/project/build.properties
+++ b/src/sbt-test/gatling-build-plugin/scalaVersion/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.4.9

--- a/src/sbt-test/scalafix/automated/project/build.properties
+++ b/src/sbt-test/scalafix/automated/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.4.9

--- a/src/sbt-test/scalafix/automated/test
+++ b/src/sbt-test/scalafix/automated/test
@@ -4,6 +4,7 @@
 -$ must-mirror src/main/scala/Hello.scala Hello.scala.expected
 
 # compile task should be dependent to our Scalafix configuration
+> set Seq(scalafixOnCompile := true)
 > compile
 # Ensure that scalafix was applied
 $ must-mirror src/main/scala/Hello.scala Hello.scala.expected

--- a/src/sbt-test/scalafix/none/project/build.properties
+++ b/src/sbt-test/scalafix/none/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.4.9

--- a/src/sbt-test/scalafix/none/test
+++ b/src/sbt-test/scalafix/none/test
@@ -1,2 +1,3 @@
+> set Seq(scalafixOnCompile := false)
 > compile
 $ must-mirror src/main/scala/Hello.scala Hello.scala.expected

--- a/src/sbt-test/scalafmt/automated/project/build.properties
+++ b/src/sbt-test/scalafmt/automated/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.4.9

--- a/src/sbt-test/scalafmt/automated/test
+++ b/src/sbt-test/scalafmt/automated/test
@@ -1,2 +1,3 @@
+> set Seq(scalafmtOnCompile := true)
 > compile
 $ must-mirror Hello.scala Hello.scala.expected

--- a/src/sbt-test/scalafmt/none/project/build.properties
+++ b/src/sbt-test/scalafmt/none/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.4.9

--- a/src/sbt-test/scalafmt/none/test
+++ b/src/sbt-test/scalafmt/none/test
@@ -1,2 +1,3 @@
+> set Seq(scalafmtOnCompile := false)
 > compile
 $ must-mirror Hello.scala Hello.scala.expected


### PR DESCRIPTION
**Motivation:**
CI must deactivate on compile scalafix and scalafmt parsing

**Modification:**
GatlingAutomatedScalafixPlugin scalafix on compile respect scalafixOnCompile setting