### PR TITLE
Check headers in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,12 @@ jobs:
 
       - name: Test
         run: |
-          sbt "all clean" "all scalafmtSbtCheck scalafmtCheckAll" "all gatlingScalafixCheck" "test" "scripted"
+          sbt \
+            "all clean" \
+            "all headerCheck" \
+            "all scalafmtSbtCheck scalafmtCheckAll" \
+            "all gatlingScalafixCheck" \
+            "test" \
+            "scripted"
         env:
           JVM_OPTS: "-Xmx6G"

--- a/src/main/scala/io/gatling/build/versioning/GatlingBump.scala
+++ b/src/main/scala/io/gatling/build/versioning/GatlingBump.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2011-2021 GatlingCorp (https://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.gatling.build.versioning
 
 import java.time.{ ZoneOffset, ZonedDateTime }


### PR DESCRIPTION
Motivation:

First 4.0.0 tag was published as 4.0.0-dirty-SNAPSHOT as a file were modified
during test (a step before publish).

Modifications:

Add a check for correct header during the build

Result:

No more modification during a release for headers