### PR TITLE
feat: Milestones are publishable versions

### DIFF
--- a/src/main/scala/io/gatling/build/GatlingOssPlugin.scala
+++ b/src/main/scala/io/gatling/build/GatlingOssPlugin.scala
@@ -59,7 +59,7 @@ object GatlingOssPlugin extends AutoPlugin {
   import autoImport._
 
   override def buildSettings: Seq[Def.Setting[_]] = Seq(
-    gatlingPublishToSonatype := ensureStableVersion(version.value)
+    gatlingPublishToSonatype := ensurePublishableVersion(version.value)
   )
 
   override def projectSettings: Seq[Def.Setting[_]] = Seq(
@@ -131,5 +131,5 @@ object GatlingOssPlugin extends AutoPlugin {
     endState
   }
 
-  def ensureStableVersion(str: String): Boolean = str.matches("\\d+\\.\\d+\\.\\d+")
+  def ensurePublishableVersion(str: String): Boolean = str.matches("\\d+\\.\\d+\\.\\d+(-M\\d+)?")
 }

--- a/src/test/scala/io/gatling/build/GatlingOssPluginSpec.scala
+++ b/src/test/scala/io/gatling/build/GatlingOssPluginSpec.scala
@@ -21,24 +21,35 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class GatlingOssPluginSpec extends AnyWordSpec with Matchers {
   "GatlingOssPlugin" when {
-    "ensure stable version" should {
-      "agree 4.0.0" in {
-        GatlingOssPlugin.ensureStableVersion("4.0.0") should be(true)
+    "ensure publishable version" should {
+      "accept 4.0.0" in {
+        GatlingOssPlugin.ensurePublishableVersion("4.0.0") should be(true)
       }
-      "disagree milestone" in {
-        GatlingOssPlugin.ensureStableVersion("4.0.0-M20210401223248") should be(false)
+      "accept simple milestone" in {
+        GatlingOssPlugin.ensurePublishableVersion("4.0.0-M1") should be(true)
       }
-      "disagree snapshot" in {
-        GatlingOssPlugin.ensureStableVersion("4.0.0-SNAPSHOT") should be(false)
+      "accept dated milestone" in {
+        GatlingOssPlugin.ensurePublishableVersion("4.0.0-M20210401223248") should be(true)
       }
-      "disagree committed" in {
-        GatlingOssPlugin.ensureStableVersion("4.0.0-2-abcdef12") should be(false)
+
+      "refuse milestone without date" in {
+        GatlingOssPlugin.ensurePublishableVersion("4.0.0-M") should be(false)
       }
-      "disagree dirty" in {
-        GatlingOssPlugin.ensureStableVersion("4.0.0-dirty-SNAPSHOT") should be(false)
+
+      "refuse milestone like" in {
+        GatlingOssPlugin.ensurePublishableVersion("4.0.0-M20210401223248abc") should be(false)
       }
-      "disagree private marker" in {
-        GatlingOssPlugin.ensureStableVersion("4.0.0.PV") should be(false)
+      "refuse snapshot" in {
+        GatlingOssPlugin.ensurePublishableVersion("4.0.0-SNAPSHOT") should be(false)
+      }
+      "refuse committed" in {
+        GatlingOssPlugin.ensurePublishableVersion("4.0.0-2-abcdef12") should be(false)
+      }
+      "refuse dirty" in {
+        GatlingOssPlugin.ensurePublishableVersion("4.0.0-dirty-SNAPSHOT") should be(false)
+      }
+      "refuse private marker" in {
+        GatlingOssPlugin.ensurePublishableVersion("4.0.0.PV") should be(false)
       }
     }
   }


### PR DESCRIPTION
Motivation:
Wanted to publish a 3.6.0-M1 version for gatling (Java, Kotlin support). But as it isn't a stable version, the build plugin refused to deliver.

Modifications:
* Enhance the verification with possible milstone marker

Result:
Will be able to publish milestone version on sonatype