### PR TITLE
feat: order qualified version before stable version, MISC-327

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       releaseType:
-        description: 'milestone|patch|minor'
+        description: 'patch-milestone|minor-milestone|patch|minor'
         required: true
 
 defaults:
@@ -24,7 +24,8 @@ jobs:
         if: |
           github.event.inputs.releaseType != 'minor' &&
           github.event.inputs.releaseType != 'patch' &&
-          github.event.inputs.releaseType != 'milestone'
+          github.event.inputs.releaseType != 'minor-milestone' &&
+          github.event.inputs.releaseType != 'patch-milestone'
 
       - uses: actions/checkout@v2
         with:

--- a/src/main/scala/io/gatling/build/versioning/GatlingVersion.scala
+++ b/src/main/scala/io/gatling/build/versioning/GatlingVersion.scala
@@ -16,15 +16,15 @@
 
 package io.gatling.build.versioning
 
-import java.text.SimpleDateFormat
-import java.util.Date
+import java.time.{ Clock, LocalDateTime, ZoneOffset }
+import java.time.format.DateTimeFormatter
 
 import scala.util.Try
 
 object GatlingVersion {
   private[GatlingVersion] lazy val MilestoneFormatterPattern = "'-M'yyyyMMddHHmmss"
   // def as SimpleDateFormat is not Thread safe
-  private[GatlingVersion] def milestoneFormatter = new SimpleDateFormat(MilestoneFormatterPattern)
+  private[GatlingVersion] def milestoneFormatter = DateTimeFormatter.ofPattern(MilestoneFormatterPattern)
   private[this] val GatlingVersionR = "(\\d+)\\.(\\d+)\\.(\\d+)(\\..*?)?(-.*)?".r
 
   def apply(str: String): Option[GatlingVersion] = {
@@ -41,7 +41,8 @@ case class GatlingVersion(major: Int, minor: Int, patch: Int, marker: Option[Str
 
   def isMilestone: Boolean = qualifier.exists(qual => Try(milestoneFormatter.parse(qual)).isSuccess)
 
-  def asMilestone: GatlingVersion = copy(qualifier = Some(milestoneFormatter.format(new Date())))
+  def asMilestone(implicit clock: Clock): GatlingVersion =
+    copy(qualifier = Some(milestoneFormatter.format(LocalDateTime.ofInstant(clock.instant(), ZoneOffset.UTC))))
 
   def isSnapshot: Boolean = qualifier.contains("-SNAPSHOT")
 

--- a/src/main/scala/io/gatling/build/versioning/GatlingVersioningPlugin.scala
+++ b/src/main/scala/io/gatling/build/versioning/GatlingVersioningPlugin.scala
@@ -16,6 +16,8 @@
 
 package io.gatling.build.versioning
 
+import java.time.Clock
+
 import com.typesafe.sbt.GitVersioning
 import com.typesafe.sbt.SbtGit.git
 
@@ -56,12 +58,15 @@ object GatlingVersioningPlugin extends AutoPlugin {
   private lazy val bumpParser: Parser[GatlingBump] =
     Space ~> (token("minor") ^^^ GatlingBump.Minor |
       token("patch") ^^^ GatlingBump.Patch |
-      token("milestone") ^^^ GatlingBump.Milestone |
-      token("calver") ^^^ GatlingBump.CalVer)
+      token("calver") ^^^ GatlingBump.CalVer) |
+      token("patch-milestone") ^^^ GatlingBump.milestone(GatlingBump.Patch) |
+      token("minor-milestone") ^^^ GatlingBump.milestone(GatlingBump.Minor) |
+      token("calver-milestone") ^^^ GatlingBump.milestone(GatlingBump.CalVer)
 
   val defaultBumpVersion = Def.inputTaskDyn {
     val bump = bumpParser.parsed
     Def.task[String] {
+      implicit val clock: Clock = Clock.systemUTC()
       val currentVersion = (ThisBuild / version).value
       GatlingVersion(currentVersion)
         .map(bump.bump)

--- a/src/test/scala/io/gatling/build/versioning/FixedClock.scala
+++ b/src/test/scala/io/gatling/build/versioning/FixedClock.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2011-2022 GatlingCorp (https://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gatling.build.versioning
+
+import java.time.{ Clock, Instant, ZoneId }
+
+trait FixedClock {
+  // 20210401041810 - 2021-04-01 04:18:10
+  implicit val clock: Clock = Clock.fixed(Instant.ofEpochSecond(1617250690L), ZoneId.of("UTC"))
+  val YYYY = 2021
+  val WW = 13
+  val YYYYMMDDHHMMSS = "20210401041810"
+  val FIXED_FORMATTED_BEFORE_TIME = "20210315062255"
+}

--- a/src/test/scala/io/gatling/build/versioning/GatlingBumpSpec.scala
+++ b/src/test/scala/io/gatling/build/versioning/GatlingBumpSpec.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2011-2022 GatlingCorp (https://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gatling.build.versioning
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks._
+import org.scalatest.wordspec.AnyWordSpec
+
+class GatlingBumpSpec extends AnyWordSpec with Matchers with FixedClock {
+  import GatlingBump._
+  private val Reference = Table(
+    // format: OFF
+    ("oldVersion"                        , "patch"             , "minor"                   , "calver"      , "patch-milestone"                    , "minor-milestone"                          , "calver-milestone"),
+    // stable
+    ("1.0.0"                             , "1.0.1"             , "1.1.0"                   , s"$YYYY.$WW.0", s"1.0.1-M$YYYYMMDDHHMMSS"            , s"1.1.0-M$YYYYMMDDHHMMSS"                  , s"$YYYY.$WW.0-M$YYYYMMDDHHMMSS"),
+    ("1.0.1"                             , "1.0.2"             , "1.1.0"                   , s"$YYYY.$WW.0", s"1.0.2-M$YYYYMMDDHHMMSS"            , s"1.1.0-M$YYYYMMDDHHMMSS"                  , s"$YYYY.$WW.0-M$YYYYMMDDHHMMSS"),
+    ("1.2.3"                             , "1.2.4"             , "1.3.0"                   , s"$YYYY.$WW.0", s"1.2.4-M$YYYYMMDDHHMMSS"            , s"1.3.0-M$YYYYMMDDHHMMSS"                  , s"$YYYY.$WW.0-M$YYYYMMDDHHMMSS"),
+    (s"${YYYY - 1}.$WW.0"                , s"${YYYY - 1}.$WW.1", s"${YYYY - 1}.${WW + 1}.0", s"$YYYY.$WW.0", s"${YYYY - 1}.$WW.1-M$YYYYMMDDHHMMSS", s"${YYYY - 1}.${WW + 1}.0-M$YYYYMMDDHHMMSS", s"$YYYY.$WW.0-M$YYYYMMDDHHMMSS"),
+    (s"$YYYY.$WW.0"                      , s"$YYYY.$WW.1"      , s"$YYYY.${WW + 1}.0"      , s"$YYYY.$WW.1", s"$YYYY.$WW.1-M$YYYYMMDDHHMMSS"      , s"$YYYY.${WW + 1}.0-M$YYYYMMDDHHMMSS"      , s"$YYYY.$WW.1-M$YYYYMMDDHHMMSS"),
+    // milestones
+    ("1.0.0-M19401225154535"             , "1.0.0"             , "1.0.0"                   , s"$YYYY.$WW.0", s"1.0.0-M$YYYYMMDDHHMMSS"            , s"1.0.0-M$YYYYMMDDHHMMSS"                  , s"$YYYY.$WW.0-M$YYYYMMDDHHMMSS"),
+    ("1.0.1-M19401225154535"             , "1.0.1"             , "1.1.0"                   , s"$YYYY.$WW.0", s"1.0.1-M$YYYYMMDDHHMMSS"            , s"1.1.0-M$YYYYMMDDHHMMSS"                  , s"$YYYY.$WW.0-M$YYYYMMDDHHMMSS"),
+    ("1.2.3-M19401225154535"             , "1.2.3"             , "1.3.0"                   , s"$YYYY.$WW.0", s"1.2.3-M$YYYYMMDDHHMMSS"            , s"1.3.0-M$YYYYMMDDHHMMSS"                  , s"$YYYY.$WW.0-M$YYYYMMDDHHMMSS"),
+    (s"${YYYY - 1}.$WW.0-M19401225154535", s"${YYYY - 1}.$WW.0", s"${YYYY - 1}.$WW.0"      , s"$YYYY.$WW.0", s"${YYYY - 1}.$WW.0-M$YYYYMMDDHHMMSS", s"${YYYY - 1}.$WW.0-M$YYYYMMDDHHMMSS"      , s"$YYYY.$WW.0-M$YYYYMMDDHHMMSS"),
+    (s"$YYYY.$WW.0-M19401225154535"      , s"$YYYY.$WW.0"      , s"$YYYY.$WW.0"            , s"$YYYY.$WW.0", s"$YYYY.$WW.0-M$YYYYMMDDHHMMSS"      , s"$YYYY.$WW.0-M$YYYYMMDDHHMMSS"            , s"$YYYY.$WW.0-M$YYYYMMDDHHMMSS"),
+    (s"$YYYY.$WW.1-M19401225154535"      , s"$YYYY.$WW.1"      , s"$YYYY.${WW + 1}.0"      , s"$YYYY.$WW.1", s"$YYYY.$WW.1-M$YYYYMMDDHHMMSS"      , s"$YYYY.${WW + 1}.0-M$YYYYMMDDHHMMSS"      , s"$YYYY.$WW.1-M$YYYYMMDDHHMMSS"),
+    // snapshots same rules as milestones
+    ("1.0.0-SNAPSHOT"                    , "1.0.0"             , "1.0.0"                   , s"$YYYY.$WW.0", s"1.0.0-M$YYYYMMDDHHMMSS"            , s"1.0.0-M$YYYYMMDDHHMMSS"                  , s"$YYYY.$WW.0-M$YYYYMMDDHHMMSS"),
+    ("1.0.1-SNAPSHOT"                    , "1.0.1"             , "1.1.0"                   , s"$YYYY.$WW.0", s"1.0.1-M$YYYYMMDDHHMMSS"            , s"1.1.0-M$YYYYMMDDHHMMSS"                  , s"$YYYY.$WW.0-M$YYYYMMDDHHMMSS"),
+    ("1.2.3-SNAPSHOT"                    , "1.2.3"             , "1.3.0"                   , s"$YYYY.$WW.0", s"1.2.3-M$YYYYMMDDHHMMSS"            , s"1.3.0-M$YYYYMMDDHHMMSS"                  , s"$YYYY.$WW.0-M$YYYYMMDDHHMMSS"),
+    (s"${YYYY - 1}.$WW.0-SNAPSHOT"       , s"${YYYY - 1}.$WW.0", s"${YYYY - 1}.$WW.0"      , s"$YYYY.$WW.0", s"${YYYY - 1}.$WW.0-M$YYYYMMDDHHMMSS", s"${YYYY - 1}.$WW.0-M$YYYYMMDDHHMMSS"      , s"$YYYY.$WW.0-M$YYYYMMDDHHMMSS"),
+    (s"$YYYY.$WW.0-SNAPSHOT"             , s"$YYYY.$WW.0"      , s"$YYYY.$WW.0"            , s"$YYYY.$WW.0", s"$YYYY.$WW.0-M$YYYYMMDDHHMMSS"      , s"$YYYY.$WW.0-M$YYYYMMDDHHMMSS"            , s"$YYYY.$WW.0-M$YYYYMMDDHHMMSS"),
+    (s"$YYYY.$WW.1-SNAPSHOT"             , s"$YYYY.$WW.1"      , s"$YYYY.${WW + 1}.0"      , s"$YYYY.$WW.1", s"$YYYY.$WW.1-M$YYYYMMDDHHMMSS"      , s"$YYYY.${WW + 1}.0-M$YYYYMMDDHHMMSS"      , s"$YYYY.$WW.1-M$YYYYMMDDHHMMSS"),
+    // format: ON
+  )
+
+  private def shouldBump(toGatlingVersion: String => GatlingVersion) =
+    forAll(Reference) {
+      (oldVersion: String, patch: String, minor: String, calVer: String, patchMilestone: String, minorMilestone: String, calVerMilestone: String) =>
+        val oldGatlingVersion = toGatlingVersion(oldVersion)
+        withClue("patch: ") {
+          Patch.bump(oldGatlingVersion) shouldBe toGatlingVersion(patch)
+        }
+        withClue("minor: ") {
+          Minor.bump(oldGatlingVersion) shouldBe toGatlingVersion(minor)
+        }
+        withClue("calver: ") {
+          CalVer.bump(oldGatlingVersion) shouldBe toGatlingVersion(calVer)
+        }
+        withClue("patchMilestone: ") {
+          milestone(Patch).bump(oldGatlingVersion) shouldBe toGatlingVersion(patchMilestone)
+        }
+        withClue("minorMilestone: ") {
+          milestone(Minor).bump(oldGatlingVersion) shouldBe toGatlingVersion(minorMilestone)
+        }
+        withClue("calverMilestone: ") {
+          milestone(CalVer).bump(oldGatlingVersion) shouldBe toGatlingVersion(calVerMilestone)
+        }
+    }
+
+  "Simple version" in {
+    shouldBump(str => GatlingVersion.apply(str).get)
+  }
+
+  "Custom marked version" in {
+    shouldBump(str => GatlingVersion.apply(str).get.copy(marker = Some("CUSTOM")))
+  }
+}

--- a/src/test/scala/io/gatling/build/versioning/GatlingVersionSpec.scala
+++ b/src/test/scala/io/gatling/build/versioning/GatlingVersionSpec.scala
@@ -19,7 +19,7 @@ package io.gatling.build.versioning
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class GatlingVersionSpec extends AnyWordSpec with Matchers {
+class GatlingVersionSpec extends AnyWordSpec with Matchers with FixedClock {
   "A version" when {
     "minor" should {
       val version = GatlingVersion("1.12.0").get
@@ -77,7 +77,7 @@ class GatlingVersionSpec extends AnyWordSpec with Matchers {
       }
 
       "asMilestone" in {
-        version.asMilestone.string should startWith("3.4.0.CUSTOMER-M")
+        version.asMilestone.string shouldBe s"3.4.0.CUSTOMER-M$YYYYMMDDHHMMSS"
       }
     }
 


### PR DESCRIPTION
Motivation:
It's confusing when milestone is set on the current published version.

Modifications:
 * Deprecated milestone bump method
 * Add a milestone bump method for patch, minor and calver

Result:
Qualifier precedes stable version