### PR TITLE
chore: update sbt-git to 2.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ lazy val root = (project in file("."))
     addSbtPlugin("com.github.sbt"    % "sbt-pgp"      % "2.1.2"),
     addSbtPlugin("de.heikoseeberger" % "sbt-header"   % "5.6.5"),
     addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype" % "3.9.12"),
-    addSbtPlugin("com.typesafe.sbt"  % "sbt-git"      % "1.0.2"),
+    addSbtPlugin("com.github.sbt"    % "sbt-git"      % "2.0.0"),
     libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.11" % Test
   )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,7 @@ addSbtPlugin("com.github.sbt"    % "sbt-release"  % "1.1.0")
 addSbtPlugin("com.github.sbt"    % "sbt-pgp"      % "2.1.2")
 addSbtPlugin("de.heikoseeberger" % "sbt-header"   % "5.6.5")
 addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype" % "3.9.10")
-addSbtPlugin("com.typesafe.sbt"  % "sbt-git"      % "1.0.2")
+addSbtPlugin("com.github.sbt"    % "sbt-git"      % "2.0.0")
 
 // This project is its own plugin :)
 Compile / unmanagedSourceDirectories += baseDirectory.value.getParentFile / "src" / "main" / "scala"

--- a/src/main/scala/io/gatling/build/versioning/GatlingVersioningPlugin.scala
+++ b/src/main/scala/io/gatling/build/versioning/GatlingVersioningPlugin.scala
@@ -20,9 +20,9 @@ import java.time.Clock
 
 import scala.util.Try
 
-import com.typesafe.sbt.GitVersioning
-import com.typesafe.sbt.SbtGit.{ git, GitKeys }
-import com.typesafe.sbt.git.JGit
+import com.github.sbt.git.GitVersioning
+import com.github.sbt.git.JGit
+import com.github.sbt.git.SbtGit.git
 
 import sbt._
 import sbt.Keys._


### PR DESCRIPTION
Motivation:
Stay up to date

Modifications:
 * change sbt-git coordinates (as required)
 * import from new package (breaking change for sbt-git hence the major version)

Result:
Up to date

Closes #90
Ref: MISC-366