### PR TITLE
fix: scalafix input task should depends on writing the configuration file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,6 @@ jobs:
             "all clean" \
             "all headerCheck" \
             "all scalafmtSbtCheck scalafmtCheckAll" \
-            "all gatlingScalafixCheck" \
+            "all scalafixAll --check" \
             "test" \
             "scripted"

--- a/build.sbt
+++ b/build.sbt
@@ -43,14 +43,3 @@ lazy val root = (project in file("."))
     addSbtPlugin("com.github.sbt"    % "sbt-git"      % "2.0.0"),
     libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.11" % Test
   )
-
-addCommandAlias(
-  "ci-checks",
-  List(
-    "all clean",
-    "all scalafmtSbtCheck scalafmtCheckAll",
-    "all gatlingScalafixCheck",
-    "test",
-    "scripted"
-  ).mkString(";", ";", "")
-)

--- a/src/main/scala/io/gatling/build/config/GatlingBuildConfigPlugin.scala
+++ b/src/main/scala/io/gatling/build/config/GatlingBuildConfigPlugin.scala
@@ -16,7 +16,7 @@
 
 package io.gatling.build.config
 
-import sbt._
+import sbt.{ Def, _ }
 import sbt.Keys._
 
 object GatlingBuildConfigPlugin extends AutoPlugin {
@@ -25,11 +25,10 @@ object GatlingBuildConfigPlugin extends AutoPlugin {
   trait GatlingBuildConfigKeys {
     val gatlingBuildConfigDirectory = settingKey[File]("Location where to put configuration from gatling-build-plugin. Defaults to target/gatling-build-config")
 
-    def writeResourceOnConfigDirectoryFile(path: String, to: Def.Initialize[File]): Def.Initialize[Task[File]] = Def.task {
+    def writeResourceOnConfigDirectoryFile(path: String, to: File): File = {
       val resourceInputStream = getClass.getResourceAsStream(path)
-      val file = to.value
-      IO.transfer(resourceInputStream, file)
-      file
+      IO.transfer(resourceInputStream, to)
+      to
     }
   }
   object GatlingBuildConfigKeys extends GatlingBuildConfigKeys

--- a/src/sbt-test/scalafix/automated/test
+++ b/src/sbt-test/scalafix/automated/test
@@ -1,5 +1,5 @@
 # Ensure that our CI will refuse the PR as is.
--> gatlingScalafixCheck
+-> scalafixAll --check
 # Ensure files were not changed
 -$ must-mirror src/main/scala/Hello.scala Hello.scala.expected
 
@@ -10,4 +10,4 @@
 $ must-mirror src/main/scala/Hello.scala Hello.scala.expected
 
 # Ensure that our CI will accept after the change
-> gatlingScalafixCheck
+> scalafixAll --check


### PR DESCRIPTION
Motivation:
During Scala steward test about using automatic migrations, we (@tpetillot and I)
found that scala-steward expected to be able to launch scalafixAll task but
during the CI for scala fix, our own task was not called, so the config file was
not written.

Modifications:
 * move task declarations inside sbt graph (better usage of sbt)
 * make scalafix and scalafixAll input task dependent on our task to copy configuration
 * [BREAKING CHANGE] remove gatlingScalafixCheck custom task

Result:
Better usage of sbt and more broad support over our different tools