### PR TITLE
feat: replace -target by -release compiler options

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,8 @@ lazy val root = (project in file("."))
     scalacOptions := Seq(
       "-encoding",
       "UTF-8",
-      "-target:jvm-1.8",
+      "-release",
+      "8",
       "-deprecation",
       "-feature",
       "-unchecked"

--- a/src/main/scala/io/gatling/build/compile/GatlingCompilerSettingsPlugin.scala
+++ b/src/main/scala/io/gatling/build/compile/GatlingCompilerSettingsPlugin.scala
@@ -43,7 +43,8 @@ object GatlingCompilerSettingsPlugin extends AutoPlugin {
         "-feature",
         "-unchecked",
         "-language:implicitConversions",
-        "-target:jvm-1.8"
+        "-release",
+        "8"
       )
 
     if (isJava8) {


### PR DESCRIPTION
Motivation:
-target for jvm is deprecated

Modifications:
 * replace -target by -release compiler options

Result:
Up to date with scalac