### PR TITLE
fix: align plugins version to export

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ lazy val root = (project in file("."))
 // ------------------ //
 // -- DEPENDENCIES -- //
 // ------------------ //
-    addSbtPlugin("org.scalameta"     % "sbt-scalafmt" % "2.4.4"),
+    addSbtPlugin("org.scalameta"     % "sbt-scalafmt" % "2.5.0"),
     addSbtPlugin("ch.epfl.scala"     % "sbt-scalafix" % "0.11.0"),
     addSbtPlugin("com.github.sbt"    % "sbt-release"  % "1.1.0"),
     addSbtPlugin("com.github.sbt"    % "sbt-pgp"      % "2.2.1"),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ addSbtPlugin("ch.epfl.scala"     % "sbt-scalafix" % "0.11.0")
 addSbtPlugin("com.github.sbt"    % "sbt-release"  % "1.1.0")
 addSbtPlugin("com.github.sbt"    % "sbt-pgp"      % "2.2.1")
 addSbtPlugin("de.heikoseeberger" % "sbt-header"   % "5.10.0")
-addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype" % "3.9.10")
+addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype" % "3.9.21")
 addSbtPlugin("com.github.sbt"    % "sbt-git"      % "2.0.1")
 
 // This project is its own plugin :)


### PR DESCRIPTION
Motivation:
as this is a project that is itself its own plugin and that export as a plugin, we need to duplicate between build.sbt and project/plugins.sbt

Modifications:
 * use same values for both sides

Result:
Aligned in auto-application and to external application