### PR TITLE
feat: replace sbt-git by sbt-dynver

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,6 +41,6 @@ lazy val root = (project in file("."))
     addSbtPlugin("com.github.sbt"    % "sbt-pgp"      % "2.2.1"),
     addSbtPlugin("de.heikoseeberger" % "sbt-header"   % "5.10.0"),
     addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype" % "3.9.21"),
-    addSbtPlugin("com.github.sbt"    % "sbt-git"      % "2.0.1"),
+    addSbtPlugin("com.github.sbt"    % "sbt-dynver"   % "5.0.1"),
     libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.17" % Test
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,7 @@ addSbtPlugin("com.github.sbt"    % "sbt-release"  % "1.1.0")
 addSbtPlugin("com.github.sbt"    % "sbt-pgp"      % "2.2.1")
 addSbtPlugin("de.heikoseeberger" % "sbt-header"   % "5.10.0")
 addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype" % "3.9.21")
-addSbtPlugin("com.github.sbt"    % "sbt-git"      % "2.0.1")
+addSbtPlugin("com.github.sbt"    % "sbt-dynver"   % "5.0.1")
 
 // This project is its own plugin :)
 Compile / unmanagedSourceDirectories += baseDirectory.value.getParentFile / "src" / "main" / "scala"


### PR DESCRIPTION
Motivations:
sbt-git is not maintained anymore. And there is a CVE on JGit that is triggered during a release.

Modifications:
 * delete sbt-git dependencies
 * add sbt-dynver
 * remove custom parsing

Result:
Work identically:
 * sbt show version is based on the last tag
 * sbt -Dproject.version="1.2.3" "show version" doesn't work anymore but version can be overridden by sbt 'set version := "1.2.3"' "show version"
 * gatlingBumpVersion and gatlingWriteBumpVersion still work