### PR TITLE
chore: overrides dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,19 +35,6 @@ lazy val root = (project in file("."))
 // ------------------ //
 // -- DEPENDENCIES -- //
 // ------------------ //
-    addSbtPlugin("org.scalameta"     % "sbt-scalafmt" % "2.5.2"),
-    addSbtPlugin("ch.epfl.scala"     % "sbt-scalafix" % "0.11.1"),
-    addSbtPlugin("com.github.sbt"    % "sbt-release"  % "1.1.0"),
-    addSbtPlugin("com.github.sbt"    % "sbt-pgp"      % "2.2.1"),
-    addSbtPlugin("de.heikoseeberger" % "sbt-header"   % "5.10.0"),
-    addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype" % "3.10.0"),
-    addSbtPlugin("com.github.sbt"    % "sbt-dynver"   % "5.0.1"),
+    PluginDependencies.deps,
     libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.17" % Test
   )
-
-ThisBuild / dependencyOverrides ++= Seq(
-  "org.eclipse.jgit"          % "org.eclipse.jgit" % "6.8.0.202311291450-r", // sbt-scalafix
-  "ch.qos.logback"            % "logback-core"     % "1.4.7", // sbt-sonatype
-  "com.google.guava"          % "guava"            % "23.0", // sbt-sonatype
-  "org.apache.httpcomponents" % "httpclient"       % "4.5.14" // sbt-sonatype
-)

--- a/build.sbt
+++ b/build.sbt
@@ -44,3 +44,10 @@ lazy val root = (project in file("."))
     addSbtPlugin("com.github.sbt"    % "sbt-dynver"   % "5.0.1"),
     libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.17" % Test
   )
+
+ThisBuild / dependencyOverrides ++= Seq(
+  "org.eclipse.jgit"          % "org.eclipse.jgit" % "6.8.0.202311291450-r", // sbt-scalafix
+  "ch.qos.logback"            % "logback-core"     % "1.4.7", // sbt-sonatype
+  "com.google.guava"          % "guava"            % "23.0", // sbt-sonatype
+  "org.apache.httpcomponents" % "httpclient"       % "4.5.14" // sbt-sonatype
+)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,9 @@
 // ------------------ //
 // -- DEPENDENCIES -- //
 // ------------------ //
-addSbtPlugin("org.scalameta"     % "sbt-scalafmt" % "2.5.2")
-addSbtPlugin("ch.epfl.scala"     % "sbt-scalafix" % "0.11.1")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.11.1")
+
 addSbtPlugin("com.github.sbt"    % "sbt-release"  % "1.1.0")
 addSbtPlugin("com.github.sbt"    % "sbt-pgp"      % "2.2.1")
 addSbtPlugin("de.heikoseeberger" % "sbt-header"   % "5.10.0")
@@ -12,3 +13,10 @@ addSbtPlugin("com.github.sbt"    % "sbt-dynver"   % "5.0.1")
 // This project is its own plugin :)
 Compile / unmanagedSourceDirectories += baseDirectory.value.getParentFile / "src" / "main" / "scala"
 Compile / unmanagedResourceDirectories += baseDirectory.value.getParentFile / "src" / "main" / "resources"
+
+dependencyOverrides ++= Seq(
+  "org.eclipse.jgit"          % "org.eclipse.jgit" % "6.8.0.202311291450-r", // sbt-scalafix
+  "ch.qos.logback"            % "logback-core"     % "1.4.7", // sbt-sonatype
+  "com.google.guava"          % "guava"            % "23.0", // sbt-sonatype
+  "org.apache.httpcomponents" % "httpclient"       % "4.5.14" // sbt-sonatype
+)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,22 +1,10 @@
 // ------------------ //
 // -- DEPENDENCIES -- //
 // ------------------ //
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.11.1")
-
-addSbtPlugin("com.github.sbt"    % "sbt-release"  % "1.1.0")
-addSbtPlugin("com.github.sbt"    % "sbt-pgp"      % "2.2.1")
-addSbtPlugin("de.heikoseeberger" % "sbt-header"   % "5.10.0")
-addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype" % "3.10.0")
-addSbtPlugin("com.github.sbt"    % "sbt-dynver"   % "5.0.1")
+PluginDependencies.deps
 
 // This project is its own plugin :)
 Compile / unmanagedSourceDirectories += baseDirectory.value.getParentFile / "src" / "main" / "scala"
 Compile / unmanagedResourceDirectories += baseDirectory.value.getParentFile / "src" / "main" / "resources"
 
-dependencyOverrides ++= Seq(
-  "org.eclipse.jgit"          % "org.eclipse.jgit" % "6.8.0.202311291450-r", // sbt-scalafix
-  "ch.qos.logback"            % "logback-core"     % "1.4.7", // sbt-sonatype
-  "com.google.guava"          % "guava"            % "23.0", // sbt-sonatype
-  "org.apache.httpcomponents" % "httpclient"       % "4.5.14" // sbt-sonatype
-)
+Compile / unmanagedSources += baseDirectory.value / "project" / "PluginDependencies.scala"

--- a/project/project/PluginDependencies.scala
+++ b/project/project/PluginDependencies.scala
@@ -1,0 +1,23 @@
+import sbt.*
+import sbt.Keys.*
+
+object PluginDependencies {
+  val deps = Seq(
+    // ------------------ //
+    // -- DEPENDENCIES -- //
+    // ------------------ //
+    addSbtPlugin("org.scalameta"     % "sbt-scalafmt" % "2.5.2"),
+    addSbtPlugin("ch.epfl.scala"     % "sbt-scalafix" % "0.11.1"),
+    addSbtPlugin("com.github.sbt"    % "sbt-release"  % "1.1.0"),
+    addSbtPlugin("com.github.sbt"    % "sbt-pgp"      % "2.2.1"),
+    addSbtPlugin("de.heikoseeberger" % "sbt-header"   % "5.10.0"),
+    addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype" % "3.10.0"),
+    addSbtPlugin("com.github.sbt"    % "sbt-dynver"   % "5.0.1"),
+    dependencyOverrides ++= Seq(
+      "org.eclipse.jgit"          % "org.eclipse.jgit" % "6.8.0.202311291450-r", // sbt-scalafix
+      "ch.qos.logback"            % "logback-core"     % "1.4.7", // sbt-sonatype
+      "com.google.guava"          % "guava"            % "23.0", // sbt-sonatype
+      "org.apache.httpcomponents" % "httpclient"       % "4.5.14" // sbt-sonatype
+    )
+  )
+}


### PR DESCRIPTION
Motivation:
Threads scan show infected dependencies.
Our direct dependencies don't have newer version (for now)

Modifications:
 * override dependency both in plugins.sbt and build.sbt (as this project is its own plugin)

Result:
Should still work (mostly compatible version)
Should avoid threats