### PR TITLE
feat: add compileAll task, MISC-483

### DIFF
--- a/src/main/scala/io/gatling/build/GatlingCorpPlugin.scala
+++ b/src/main/scala/io/gatling/build/GatlingCorpPlugin.scala
@@ -17,7 +17,7 @@
 package io.gatling.build
 
 import io.gatling.build.automated.{ GatlingAutomatedScalafixPlugin, GatlingAutomatedScalafmtPlugin }
-import io.gatling.build.basic.GatlingBasicInfoPlugin
+import io.gatling.build.basic.{ GatlingBasicInfoPlugin, GatlingCompileAllPlugin }
 import io.gatling.build.compile.GatlingCompilerSettingsPlugin
 import io.gatling.build.environment.GatlingEnvPlugin
 import io.gatling.build.license._
@@ -37,6 +37,7 @@ object GatlingCorpPlugin extends AutoPlugin {
       GatlingAutomatedScalafmtPlugin &&
       GatlingVersioningPlugin &&
       GatlingBasicInfoPlugin &&
+      GatlingCompileAllPlugin &&
       GatlingCompilerSettingsPlugin &&
       GatlingPublishPlugin &&
       GatlingReleasePlugin &&

--- a/src/main/scala/io/gatling/build/GatlingEnterpriseComponentPlugin.scala
+++ b/src/main/scala/io/gatling/build/GatlingEnterpriseComponentPlugin.scala
@@ -17,6 +17,7 @@
 package io.gatling.build
 
 import io.gatling.build.automated.{ GatlingAutomatedScalafixPlugin, GatlingAutomatedScalafmtPlugin }
+import io.gatling.build.basic.GatlingCompileAllPlugin
 import io.gatling.build.compile.GatlingCompilerSettingsPlugin
 import io.gatling.build.environment.GatlingEnvPlugin
 import io.gatling.build.license._
@@ -38,6 +39,7 @@ object GatlingEnterpriseComponentPlugin extends AutoPlugin {
       GatlingAutomatedScalafmtPlugin &&
       GatlingVersioningPlugin &&
       GatlingCompilerSettingsPlugin &&
+      GatlingCompileAllPlugin &&
       AutomateHeaderPlugin &&
       GatlingEnvPlugin &&
       GatlingEnterpriseComponentLicenseFilePlugin &&

--- a/src/main/scala/io/gatling/build/GatlingOssPlugin.scala
+++ b/src/main/scala/io/gatling/build/GatlingOssPlugin.scala
@@ -18,6 +18,7 @@ package io.gatling.build
 
 import io.gatling.build.automated.GatlingAutomatedScalafixPlugin
 import io.gatling.build.automated.GatlingAutomatedScalafmtPlugin
+import io.gatling.build.basic.GatlingCompileAllPlugin
 import io.gatling.build.compile.GatlingCompilerSettingsPlugin
 import io.gatling.build.license._
 import io.gatling.build.sonatype.GatlingSonatypePlugin
@@ -35,6 +36,7 @@ object GatlingOssPlugin extends AutoPlugin {
       GatlingAutomatedScalafmtPlugin &&
       GatlingVersioningPlugin &&
       GatlingCompilerSettingsPlugin &&
+      GatlingCompileAllPlugin &&
       AutomateHeaderPlugin &&
       Apache2LicenseFilePlugin &&
       GatlingSonatypePlugin

--- a/src/main/scala/io/gatling/build/basic/GatlingCompileAllPlugin.scala
+++ b/src/main/scala/io/gatling/build/basic/GatlingCompileAllPlugin.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2011-2024 GatlingCorp (https://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gatling.build.basic
+
+import sbt._
+import sbt.Keys._
+
+object GatlingCompileAllPlugin extends AutoPlugin {
+  override def requires = empty
+
+  override def trigger = allRequirements
+
+  trait GatlingCompileAllKeys {
+    val compileAll = taskKey[Unit]("compile all configurations")
+  }
+  object GatlingCompileAllKeys extends GatlingCompileAllKeys
+  object autoImport extends GatlingCompileAllKeys
+
+  import autoImport._
+
+  override def projectSettings: Seq[Def.Setting[_]] = Seq(
+    compileAll := compile.?.all(
+      ScopeFilter(
+        configurations = inAnyConfiguration
+      )
+    ).value
+  )
+}


### PR DESCRIPTION
Motivation:
We define this helper in different projects

Modifications:
 * Add a plugin to declare this

Result:
The developer can now launch `sbt compileAll` or better `sbt ~compileAll` in order to compile all configurations for all projects (if root is the aggregated projects)