### PR TITLE
feat: use OrganizeImports scalafix built-in rule, MISC-485

### DIFF
--- a/src/main/resources/default.scalafix.conf
+++ b/src/main/resources/default.scalafix.conf
@@ -1,13 +1,20 @@
 rule = [
-  SortImports
+  OrganizeImports,
+  RedundantSyntax // remove extra string interpolator when not needed
 ]
 
-SortImports.blocks = [
-  "re:javax?\\.",
-  "scala.",
-  "io.gatling.",
-  "*",
-  "re:x?sbti?\\."
-]
-
-SortImports.asciiSort = false
+OrganizeImports {
+  blankLines = Auto
+  expandRelative = true
+  groupedImports = Merge
+  groups = [
+    "re:javax?\\.",
+    "scala.",
+    "io.gatling.",
+    "*",
+    "re:x?sbti?\\."
+  ]
+  importSelectorsOrder = SymbolsFirst
+  importsOrder = SymbolsFirst
+  removeUnused = false
+}

--- a/src/main/scala/io/gatling/build/GatlingOssPlugin.scala
+++ b/src/main/scala/io/gatling/build/GatlingOssPlugin.scala
@@ -16,8 +16,7 @@
 
 package io.gatling.build
 
-import io.gatling.build.automated.GatlingAutomatedScalafixPlugin
-import io.gatling.build.automated.GatlingAutomatedScalafmtPlugin
+import io.gatling.build.automated.{ GatlingAutomatedScalafixPlugin, GatlingAutomatedScalafmtPlugin }
 import io.gatling.build.basic.GatlingCompileAllPlugin
 import io.gatling.build.compile.GatlingCompilerSettingsPlugin
 import io.gatling.build.license._

--- a/src/main/scala/io/gatling/build/automated/GatlingAutomatedScalafixPlugin.scala
+++ b/src/main/scala/io/gatling/build/automated/GatlingAutomatedScalafixPlugin.scala
@@ -21,7 +21,8 @@ import io.gatling.build.config.GatlingBuildConfigPlugin
 import scalafix.sbt.ScalafixPlugin
 import scalafix.sbt.ScalafixPlugin.autoImport._
 
-import sbt.{ Def, _ }
+import sbt._
+import sbt.Keys._
 
 object GatlingAutomatedScalafixPlugin extends AutoPlugin {
   override def requires: Plugins = ScalafixPlugin && GatlingBuildConfigPlugin
@@ -60,6 +61,8 @@ object GatlingAutomatedScalafixPlugin extends AutoPlugin {
         }
       )
 
-  override def buildSettings: Seq[Def.Setting[_]] =
-    ThisBuild / scalafixDependencies += "com.nequissimus" %% "sort-imports" % "0.6.1"
+  override def buildSettings: Seq[Def.Setting[_]] = Seq(
+    semanticdbEnabled := true,
+    semanticdbVersion := scalafixSemanticdb.revision
+  )
 }

--- a/src/main/scala/io/gatling/build/sonatype/GatlingSonatypePlugin.scala
+++ b/src/main/scala/io/gatling/build/sonatype/GatlingSonatypePlugin.scala
@@ -91,7 +91,7 @@ object GatlingSonatypePlugin extends AutoPlugin {
      *  - inject it to the state needed by publishSigned task
      *  - call sonatypeClose command with full state from sonatypeOpen
      */
-    state.log.info(s"Opening sonatype staging")
+    state.log.info("Opening sonatype staging")
     val sonatypeOpenState = releaseStepCommandAndRemaining("sonatypeOpen")(state)
     val sonatypeTargetRepositoryProfileValue = sonatypeOpenState.getSetting(sonatypeTargetRepositoryProfile).get
 

--- a/src/sbt-test/gatling-build-plugin/loadPlugin/build.sbt
+++ b/src/sbt-test/gatling-build-plugin/loadPlugin/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion := "2.13.12"
+scalaVersion := "2.13.16"
 
 githubPath := "user/repository"
 

--- a/src/sbt-test/gatling-build-plugin/loadPlugin/project/build.properties
+++ b/src/sbt-test/gatling-build-plugin/loadPlugin/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.7
+sbt.version=1.10.7

--- a/src/sbt-test/gatling-build-plugin/scalaVersion/project/build.properties
+++ b/src/sbt-test/gatling-build-plugin/scalaVersion/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.7
+sbt.version=1.10.7

--- a/src/sbt-test/scalafix/automated/build.sbt
+++ b/src/sbt-test/scalafix/automated/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion := "2.13.12"
+scalaVersion := "2.13.16"
 githubPath := "user/repository"
 
 lazy val root = (project in file("."))

--- a/src/sbt-test/scalafix/automated/project/build.properties
+++ b/src/sbt-test/scalafix/automated/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.7
+sbt.version=1.10.7

--- a/src/sbt-test/scalafix/none/build.sbt
+++ b/src/sbt-test/scalafix/none/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion := "2.13.12"
+scalaVersion := "2.13.16"
 githubPath := "user/repository"
 
 lazy val root = (project in file("."))

--- a/src/sbt-test/scalafix/none/project/build.properties
+++ b/src/sbt-test/scalafix/none/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.7
+sbt.version=1.10.7

--- a/src/sbt-test/scalafmt/automated/build.sbt
+++ b/src/sbt-test/scalafmt/automated/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion := "2.13.12"
+scalaVersion := "2.13.16"
 ThisBuild / scalafixDependencies += "org.scalameta" % "sbt-scalafmt" % "2.5.4"
 githubPath := "user/repository"
 

--- a/src/sbt-test/scalafmt/automated/project/build.properties
+++ b/src/sbt-test/scalafmt/automated/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.7
+sbt.version=1.10.7

--- a/src/sbt-test/scalafmt/none/build.sbt
+++ b/src/sbt-test/scalafmt/none/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion := "2.13.12"
+scalaVersion := "2.13.16"
 githubPath := "user/repository"
 
 lazy val root = (project in file("."))

--- a/src/sbt-test/scalafmt/none/project/build.properties
+++ b/src/sbt-test/scalafmt/none/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.7
+sbt.version=1.10.7


### PR DESCRIPTION
Motivation:
NeQuissimus/sort-imports is no longer maintained. Even though it works very well, scalafix complains about it being compiled against scalafix 0.9 and pollutes the logs.

Modifications:
 * Configure the "new" OrganizeImports built-in rule to be as close as possible from current code

Result:
Small changes in code but use an uptodate version of scalafix rule