### PR TITLE
feat: fully release instead of only upload to sonatype

### DIFF
--- a/src/main/scala/io/gatling/build/sonatype/GatlingSonatypePlugin.scala
+++ b/src/main/scala/io/gatling/build/sonatype/GatlingSonatypePlugin.scala
@@ -90,7 +90,7 @@ object GatlingSonatypePlugin extends AutoPlugin {
     }
 
     state.log.info("Upload to sonatype")
-    releaseStepCommandAndRemaining("sonatypeCentralUpload")(endState)
+    releaseStepCommandAndRemaining("sonatypeCentralRelease")(endState)
     endState
   }
 


### PR DESCRIPTION
Motivation:
We don't check anything lately before manually clicking on publish on Sonatype website

Modification:
Directly ask for publication through the API

Result:
Less time to wait (no manual click)